### PR TITLE
Docs/bot env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,6 @@ FACTORIO_LOG=C:\Users\xx\AppData\Roaming\Factorio\console.log
 MOD_LOG=C:\Users\xx\AppData\Roaming\Factorio\script-output\factorigo-chat-bot\factorigo-chat-bot.log
 POLL_LOG=false
 ALL_ROCKET_LAUNCHES=false
-ACHIEVEMENT_MODE=false
+ACHIEVEMENT_MODE=true
 SEND_GPS_PING=false
 SEND_JOIN_LEAVE=true

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ FACTORIO_LOG=C:\Users\xx\AppData\Roaming\Factorio\console.log (Unix path also su
 MOD_LOG=C:\Users\xx\AppData\Roaming\Factorio\script-output\factorigo-chat-bot\factorigo-chat-bot.log (Optional) # If you use the companion mod supply the path to that log file here
 POLL_LOG=false # If this is set, logs will be polled instead of using inotify. This may be required with docker depending on your storage setup
 ALL_ROCKET_LAUNCHES=false # By default it will say only some rocket launches (1, 10, 100 etc). If you want to see all set this to true
-ACHIEVEMENT_MODE=true # For nicer text-layout (and possible some special commands in the future), we need to execute commands. THIS WILL DISABLE ACHIEVEMENTS.
+ACHIEVEMENT_MODE=true # Set `false` for nicer text-layout (and possible some special commands in the future), we need to execute commands `/silent-command game.print(...)`. THIS WILL DISABLE ACHIEVEMENTS.
 SEND_GPS_PING=false # If this is set, the bot will send all GPS/Location pings to Discord
 SEND_JOIN_LEAVE=true # Set to false if you don't want join/leave events to be send to Discord
 ```


### PR DESCRIPTION
- https://github.com/Mattie112/FactoriGOChatBot/commit/5c7d8b4c6e5a97e01e227eac965d680eb585f1fa:
  The defalut/recommended value for `ACHIEVEMENT_MODE` is set to `false` in [`.env.example`](https://github.com/Mattie112/FactoriGOChatBot/blob/f5e3089521933bc04701ff54a92b03ea6298ecff/.env.example#L11), but it's `true` in the [`README.md`](https://github.com/Mattie112/FactoriGOChatBot/blob/f5e3089521933bc04701ff54a92b03ea6298ecff/README.md?plain=1#L69). I've aligned them both to `true`, as i believe it’s risky to enable a feature that disables player achievements by default.
- https://github.com/Mattie112/FactoriGOChatBot/commit/ee99ed909aa2b2fe429c50302c40a573773f7d62:
  Accourding to the code:
   https://github.com/Mattie112/FactoriGOChatBot/blob/f5e3089521933bc04701ff54a92b03ea6298ecff/main.go#L262-L266

  Setting to 'true' for Steam Achievements, setting to 'false' for nicer text-layout. But the description in `README.md` is easy to misunderstand as: setting it to 'true' will improve visual effects but will disable Steam achievements. At least for me, that's the case.