### PR TITLE
enhance: set default value of envs according to `README.md`'s Bot section

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func loadConfig() botConfig {
 		log.WithError(err).Error("Cannot load Config")
 	}
 	return botConfig{
-		logLevel:          getEnvOrDefault("LOG_LEVEL", "info"),
+		logLevel:          getEnvStrOrDefault("LOG_LEVEL", "info"),
 		discordToken:      os.Getenv("DISCORD_TOKEN"),
 		discordChannelId:  os.Getenv("DISCORD_CHANNEL_ID"),
 		rconIp:            ip,
@@ -113,20 +113,6 @@ func loadConfig() botConfig {
 		sendGPSPing:       getEnvOrDefaultBool("SEND_GPS_PING", false),
 		sendJoinLeave:     getEnvOrDefaultBool("SEND_JOIN_LEAVE", true),
 	}
-}
-
-func getEnvOrDefault(key, defaultVal string) string {
-	if value, exists := os.LookupEnv(key); exists {
-		return value
-	}
-	return defaultVal
-}
-
-func getEnvOrDefaultBool(key string, defaultVal bool) bool {
-	if value, exists := os.LookupEnv(key); exists {
-		return value == "true"
-	}
-	return defaultVal
 }
 
 // Parse the message and format it in a way for Discord

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func loadConfig() botConfig {
 		log.WithError(err).Error("Cannot load Config")
 	}
 	return botConfig{
-		logLevel:          os.Getenv("LOG_LEVEL"),
+		logLevel:          getEnvOrDefault("LOG_LEVEL", "info"),
 		discordToken:      os.Getenv("DISCORD_TOKEN"),
 		discordChannelId:  os.Getenv("DISCORD_CHANNEL_ID"),
 		rconIp:            ip,
@@ -103,12 +103,26 @@ func loadConfig() botConfig {
 		rconPassword:      os.Getenv("RCON_PASSWORD"),
 		factorioLog:       os.Getenv("FACTORIO_LOG"),
 		modLog:            os.Getenv("MOD_LOG"),
-		pollLog:           getEnvBool("POLL_LOG"),
-		allRocketLaunches: getEnvBool("ALL_ROCKET_LAUNCHES"),
-		achievementMode:   getEnvBool("ACHIEVEMENT_MODE"),
-		sendGPSPing:       getEnvBool("SEND_GPS_PING"),
-		sendJoinLeave:     getEnvBool("SEND_JOIN_LEAVE"),
+		pollLog:           getEnvOrDefaultBool("POLL_LOG", false),
+		allRocketLaunches: getEnvOrDefaultBool("ALL_ROCKET_LAUNCHES", false),
+		achievementMode:   getEnvOrDefaultBool("ACHIEVEMENT_MODE", true),
+		sendGPSPing:       getEnvOrDefaultBool("SEND_GPS_PING", false),
+		sendJoinLeave:     getEnvOrDefaultBool("SEND_JOIN_LEAVE", true),
 	}
+}
+
+func getEnvOrDefault(key, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultVal
+}
+
+func getEnvOrDefaultBool(key string, defaultVal bool) bool {
+	if value, exists := os.LookupEnv(key); exists {
+		return value == "true"
+	}
+	return defaultVal
 }
 
 // Parse the message and format it in a way for Discord

--- a/utils.go
+++ b/utils.go
@@ -49,26 +49,23 @@ func getLoggerFromConfig(logLevel string) *logrus.Logger {
 	return log
 }
 
-func getEnvStr(key string) (string, error) {
-	v := os.Getenv(key)
-	return v, nil
+func getEnvStrOrDefault(key, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultVal
 }
 
-func getEnvBool(key string) bool {
-	s, err := getEnvStr(key)
-	if err != nil {
-		log.WithField("envVar", key).WithError(err).Error("Cannot parse env variable as boolean")
-		return false
+func getEnvOrDefaultBool(key string, defaultVal bool) bool {
+	if value, exists := os.LookupEnv(key); exists {
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			log.WithField("envVar", key).WithError(err).Error("Cannot parse env variable as boolean")
+			return defaultVal
+		}
+		return b
 	}
-	if s == "" {
-		return false // No env var is false
-	}
-	v, err := strconv.ParseBool(s)
-	if err != nil {
-		log.WithField("envVar", key).WithError(err).Error("Cannot parse env variable as boolean")
-		return false
-	}
-	return v
+	return defaultVal
 }
 
 func validateIpOrHostname(input string) (string, error) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -61,7 +61,7 @@ func Test_getEnvOrDefaultBool(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv(tt.args.key, fmt.Sprintf("%v", tt.args.valueToSet))
+			_ = os.Setenv(tt.args.key, fmt.Sprintf("%v", tt.args.valueToSet))
 			if got := getEnvOrDefaultBool(tt.args.key, tt.args.defaultVal); got != tt.want {
 				t.Errorf("getEnvOrDefaultBool() = %v, want %v", got, tt.want)
 			}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"io"
+	"os"
+	"testing"
+)
 
 func Test_validateIpOrHostname(t *testing.T) {
 	type args struct {
@@ -27,6 +33,37 @@ func Test_validateIpOrHostname(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("validateIpOrHostname() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getEnvOrDefaultBool(t *testing.T) {
+	log = logrus.New()
+	log.Out = io.Discard
+	type args struct {
+		key        string
+		valueToSet interface{}
+		defaultVal bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"true string", args{"key", "true", true}, true},
+		{"true bool", args{"key", true, true}, true},
+		{"true int", args{"key", 1, true}, true},
+		{"true empty", args{"key", nil, true}, true},
+		{"true parse error default", args{"key", "xxx", true}, true},
+		{"false string", args{"key", "false", true}, false},
+		{"false bool", args{"key", false, true}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(tt.args.key, fmt.Sprintf("%v", tt.args.valueToSet))
+			if got := getEnvOrDefaultBool(tt.args.key, tt.args.defaultVal); got != tt.want {
+				t.Errorf("getEnvOrDefaultBool() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
The improvement for the scenario mentioned in https://github.com/Mattie112/FactoriGOChatBot/issues/33#issuecomment-2452969652 :

> Which means I have to set sendJoinLeave if I want to enable the feature, it's not frendly enought for docker user - since we have to assign ALL variables into enviorments section.