### PR TITLE
refactor/players_online_count

### DIFF
--- a/main.go
+++ b/main.go
@@ -396,13 +396,13 @@ func getSeedFromFactorio(rconClient *rcon.Client) string {
 	return seed
 }
 
-func getPlayersOnlineFromFactorio(rconClient *rcon.Client) (int, error) {
+func getPlayersOnlineFromFactorio(rconClient RconClient) (int, error) {
 	msg, err := rconClient.Execute("/players online count")
 	if err != nil {
 		log.WithFields(logrus.Fields{"err": err}).Error("Could not get player count from Factorio")
 		return 0, err
 	}
-	playersOnline, err := strconv.Atoi(strings.Split(strings.Split(msg, "(")[1], ")")[0])
+	playersOnline, err = strconv.Atoi(strings.Split(strings.Split(msg, "(")[1], ")")[0])
 	if err != nil {
 		log.WithFields(logrus.Fields{"err": err}).Panic("Could not parse player count from Factorio")
 		return 0, err
@@ -410,8 +410,8 @@ func getPlayersOnlineFromFactorio(rconClient *rcon.Client) (int, error) {
 	return playersOnline, nil
 }
 
-func updatePlayerCount(rconClient *rcon.Client) {
-	getPlayersOnlineFromFactorio(rconClient)
+func updatePlayerCount(rconClient RconClient) {
+	_, _ = getPlayersOnlineFromFactorio(rconClient)
 	if playersOnline > 0 {
 		updateDiscordStatus(discordgo.ActivityTypeWatching, "the factory grow")
 	} else {

--- a/main.go
+++ b/main.go
@@ -396,18 +396,18 @@ func getSeedFromFactorio(rconClient *rcon.Client) string {
 	return seed
 }
 
-func getPlayersOnlineFromFactorio(rconClient *rcon.Client) int {
+func getPlayersOnlineFromFactorio(rconClient *rcon.Client) (int, error) {
 	msg, err := rconClient.Execute("/players online count")
 	if err != nil {
 		log.WithFields(logrus.Fields{"err": err}).Error("Could not get player count from Factorio")
-		return
+		return 0, err
 	}
-	playersOnline, err = strconv.Atoi(strings.Split(strings.Split(msg, "(")[1], ")")[0])
+	playersOnline, err := strconv.Atoi(strings.Split(strings.Split(msg, "(")[1], ")")[0])
 	if err != nil {
 		log.WithFields(logrus.Fields{"err": err}).Panic("Could not parse player count from Factorio")
-		return
+		return 0, err
 	}
-	return playersOnline
+	return playersOnline, nil
 }
 
 func updatePlayerCount(rconClient *rcon.Client) {
@@ -449,7 +449,10 @@ func handleCommands(rconClient *rcon.Client) {
 	for command := range commands {
 		switch command {
 		case "!online":
-			messagesToDiscord <- strconv.Itoa(getPlayersOnlineFromFactorio(rconClient)) + " players online"
+			playersOnline, err := getPlayersOnlineFromFactorio(rconClient)
+			if err == nil {
+				messagesToDiscord <- strconv.Itoa(playersOnline) + " players online"
+			}
 			break
 		case "!seed":
 			messagesToDiscord <- getSeedFromFactorio(rconClient)


### PR DESCRIPTION
<details>
  <summary>Background Summary</summary>

  Currently `!online` command directly display the value of global varaible `playersOnline`:
  
  https://github.com/Mattie112/FactoriGOChatBot/blob/143ba61cb4a7621a458e9097402d5b023da34ea8/main.go#L448-L450
  
  , which is plused/minused by `parseAndFormatMessage`:
  
  https://github.com/Mattie112/FactoriGOChatBot/blob/143ba61cb4a7621a458e9097402d5b023da34ea8/main.go#L150-L165
  
  and updated by `updatePlayerCount`:
  
  https://github.com/Mattie112/FactoriGOChatBot/blob/143ba61cb4a7621a458e9097402d5b023da34ea8/main.go#L401-L417

</details>

I noticed that the `parseAndFormatMessage` function's mechanism for increasing or decreasing the online user(player) count in JOIN/LEAVE scenarios fails to calculate correctly due to repeated logins after abnormal disconnections, such as unexpected logouts.

|Discord|`console.log`|
|-|-|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/be83f766-47ae-436d-a883-1639d073fc1f">|<img width="400" alt="image" src="https://github.com/user-attachments/assets/02e81e5f-1bc0-4312-bbfc-38bc69aaec82">|

Therefore, I've refactored the functions related to `playersOnline`. Now, whenever `!online` is entered, FactoriGOChatBot will re-execute `/players online count` on the server to ensure the latest player count is retrieved. Additionally, `parseAndFormatMessage` will no longer affect `playersOnline` to ensure the stability of the online player count functionality..
