### PR TITLE
Fixed bot online message being repeated

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func parseAndFormatMessage(message string) string {
 		// Extracted to keep this function small
 		return parseModLogEntries(message)
 	case "CHAT":
-		var re = regexp.MustCompile(`(?m)] (.*): (.*)`)
+		var re = regexp.MustCompile(`(?mU)] (.*): (.*?)`)
 		match := re.FindStringSubmatch(message)
 
 		// Ignore GPS (= map pings)
@@ -142,7 +142,7 @@ func parseAndFormatMessage(message string) string {
 		}
 
 		// When using achievement mode, ignore all messages from the server to prevent a message-loop
-		if config.achievementMode && strings.HasPrefix(match[1], "<server>: ") {
+		if config.achievementMode && strings.HasPrefix(match[1], "<server>") {
 			return ""
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -74,6 +74,7 @@ func Test_parseAndFormatMessage(t *testing.T) {
 		{"GPS-hide", args{message: "2022-04-14 19:41:54 [CHAT] Mattie: [gps=98,69]"}, ""},
 		{"GPS-show", args{message: "2022-04-14 19:41:54 [CHAT] Mattie: [gps=98,69]", config: botConfig{sendGPSPing: true}}, ":map: | `Mattie`: [gps=98,69]"},
 		{"message-loop-issue-#28", args{message: "2024-10-31 20:15:53 [CHAT] <server>: [color=#7289DA][Discord][Mattie]: test123[/color]", config: botConfig{achievementMode: true}}, ""},
+		{"message-loop-issue-#37", args{message: "2024-10-31 20:15:53 [CHAT] <server>: [color=#7289DA][Discord]FactoriGO Chat Bot is online![/color]", config: botConfig{achievementMode: true}}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Changed regex so it should match correctly for all cases. I will just match on `<server>` now.

![image](https://github.com/user-attachments/assets/9a172b36-af08-4a50-80f1-1720acb48ffc)

https://regex101.com/r/LROR2A/1